### PR TITLE
Remove gemset creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,7 @@ Install the correct Ruby version (latest stable at the time of starting the proj
 rbenv install 3.0.2
 ```
 
-Create a gemset called `clinical-safety` so that it will be automatically selected by `rbenv` when you are in the project root directory.
-
-```shell
-rbenv gemset create 3.0.2 clinical-safety
-```
-
-Install all the dependencies to this `clinical-safety` gemset
+Install all the dependencies
 
 ```shell
 bundle install


### PR DESCRIPTION
You [don't need to create gemsets with bundler and their use has diminished in the last few years](https://stackoverflow.com/questions/9771172/rbenv-surviving-without-gemsets).
To install gemsets via rbenv, you have to [add a plugin](https://github.com/jf/rbenv-gemset).